### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ follows:
 ```groovy
 buildscript {
     repositories {
-        maven { url 'http://repo.spring.io/plugins-release' }
+        maven { url 'https://repo.spring.io/plugins-release' }
     }
     dependencies {
         classpath 'io.spring.gradle:propdeps-plugin:0.0.9.RELEASE'

--- a/src/main/groovy/io/spring/gradle/propdeps/PropDepsIdeaPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/propdeps/PropDepsIdeaPlugin.groovy
@@ -26,8 +26,8 @@ import org.gradle.plugins.ide.idea.IdeaPlugin
  *
  * @author Phillip Webb
  * @author Brian Clozel
- * @link http://youtrack.jetbrains.com/issue/IDEA-107046
- * @link http://youtrack.jetbrains.com/issue/IDEA-117668
+ * @link https://youtrack.jetbrains.com/issue/IDEA-107046
+ * @link https://youtrack.jetbrains.com/issue/IDEA-117668
  */
 class PropDepsIdeaPlugin implements Plugin<Project> {
 

--- a/src/main/groovy/io/spring/gradle/propdeps/PropDepsPlugin.groovy
+++ b/src/main/groovy/io/spring/gradle/propdeps/PropDepsPlugin.groovy
@@ -40,7 +40,7 @@ import org.gradle.api.tasks.javadoc.Javadoc
  * @author Brian Clozel
  * @author Rob Winch
  *
- * @see <a href="http://www.gradle.org/docs/current/userguide/java_plugin.html#N121CF">Maven documentation</a>
+ * @see <a href="https://www.gradle.org/docs/current/userguide/java_plugin.html#N121CF">Maven documentation</a>
  * @see <a href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Scope">Gradle configurations</a>
  * @see PropDepsEclipsePlugin
  * @see PropDepsIdeaPlugin


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://youtrack.jetbrains.com/issue/IDEA-107046 with 1 occurrences migrated to:  
  https://youtrack.jetbrains.com/issue/IDEA-107046 ([https](https://youtrack.jetbrains.com/issue/IDEA-107046) result 200).
* [ ] http://youtrack.jetbrains.com/issue/IDEA-117668 with 1 occurrences migrated to:  
  https://youtrack.jetbrains.com/issue/IDEA-117668 ([https](https://youtrack.jetbrains.com/issue/IDEA-117668) result 200).
* [ ] http://www.gradle.org/docs/current/userguide/java_plugin.html with 1 occurrences migrated to:  
  https://www.gradle.org/docs/current/userguide/java_plugin.html ([https](https://www.gradle.org/docs/current/userguide/java_plugin.html) result 301).
* [ ] http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).